### PR TITLE
#44管理画面 Issue3 画面からイベント情報を変更出来るようにする

### DIFF
--- a/src/admin/event-edit.php
+++ b/src/admin/event-edit.php
@@ -1,0 +1,88 @@
+<?php
+session_start();
+require('../dbconnect.php');
+
+if (!isset($_SESSION['admin']) || !$_SESSION['admin']) {
+    header('Location: /auth/logout.php');
+    exit();
+}
+$post_id = filter_input(INPUT_GET, 'id', FILTER_SANITIZE_NUMBER_INT);
+if (!$post_id) {
+    header('Location: index.php');
+    exit();
+}
+
+$stmt = $db->prepare('select * from events where id = ?');
+$stmt->bindValue(1, $post_id);
+$stmt->execute();
+$event = $stmt->fetch();
+$start_at = new DateTime($event['start_at']);
+$end_at = new DateTime($event['end_at']);
+
+
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $form['name'] = filter_input(INPUT_POST, 'name', FILTER_SANITIZE_SPECIAL_CHARS);
+    $form['message'] = filter_input(INPUT_POST, 'message', FILTER_UNSAFE_RAW);
+    $form['start_at'] = filter_input(INPUT_POST, 'start_at', FILTER_SANITIZE_NUMBER_INT);
+	$form['end_at'] = filter_input(INPUT_POST, 'end_at', FILTER_SANITIZE_NUMBER_INT);
+
+	$stmt = $db->prepare('update events set name=?, message=?, start_at=?, end_at=? where id=?');
+    $stmt->bindValue(1, $form['name']);
+    $stmt->bindValue(2, $form['message']);
+    $start_at = new DateTime($form['start_at']);
+    $stmt->bindValue(3, $start_at->format('Y-m-d H:i:s'));
+    $end_at = new DateTime($form['end_at']);
+	$stmt->bindValue(4, $end_at->format('Y-m-d H:i:s'));
+    $stmt->bindValue(5, $post_id, PDO::PARAM_INT);
+	$stmt->execute();
+	header('Location: index.php');
+}
+
+?>
+<!DOCTYPE html>
+<html lang="ja">
+
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link href="https://unpkg.com/tailwindcss@^2/dist/tailwind.min.css" rel="stylesheet">
+    <title>Schedule | POSSE</title>
+</head>
+
+<body>
+    <header class="h-16">
+        <div class="flex justify-between items-center w-full h-full mx-auto pl-2 pr-5">
+            <div class="h-full">
+                <img src="../img/header-logo.png" alt="" class="h-full">
+            </div>
+            <div>
+                <?php if ($_SESSION['admin']) : ?>
+                    <a href="../index.php" class="text-white bg-blue-400 px-4 py-2 rounded-3xl bg-gradient-to-r from-blue-600 to-blue-200">ユーザー画面へ</a>
+                <?php endif; ?>
+                <a href="/auth/logout.php" class="">ログアウト</a>
+            </div>
+        </div>
+    </header>
+
+
+    <main class="bg-gray-100 h-screen">
+        <div class="w-full mx-auto py-10 px-5">
+            <ul>
+                <div class="w-full mx-auto py-10 px-5">
+                    <h2 class="text-md font-bold mb-5">イベント編集</h2>
+                    <form action="" method="POST">
+                        <input type="name" name="name" placeholder="イベント名" class="w-full p-4 text-sm mb-3" value=<?= h($event['name']) ?> required>
+                        <input type="datetime-local" name="start_at" placeholder="開始日時" class="w-full p-4 text-sm mb-3"  value=<?= h($start_at->format('Y-m-d\TH:i')) ?> required>
+                        <input type="datetime-local" name="end_at" placeholder="終了日時" class="w-full p-4 text-sm mb-3"  value=<?= h($end_at->format('Y-m-d\TH:i')) ?> required>
+                        <input type="text" name="message" placeholder="イベント内容" class="w-full p-4 text-sm mb-3"  value=<?= h($event['message']) ?>>
+                        <input type="submit" value="編集" class="cursor-pointer w-full p-3 text-md text-white bg-blue-400 rounded-3xl bg-gradient-to-r from-blue-600 to-blue-300">
+                    </form>
+                </div>
+            </ul>
+        </div>
+    </main>
+</body>
+
+</html>

--- a/src/admin/events.php
+++ b/src/admin/events.php
@@ -6,7 +6,6 @@ if (!isset($_SESSION['admin']) || !$_SESSION['admin']) {
     header('Location: /auth/logout.php');
     exit();
 }
-
 ?>
 <!DOCTYPE html>
 <html lang="ja">
@@ -34,14 +33,31 @@ if (!isset($_SESSION['admin']) || !$_SESSION['admin']) {
         </div>
     </header>
 
-
     <main class="bg-gray-100 h-screen">
         <div class="w-full mx-auto py-10 px-5">
-            <ul>
-                <li><a href="user-register.php">・ユーザー登録</a></li>
-                <li><a href="event-register.php">・イベント登録</a></li>
-                <li><a href="events.php">・イベント編集</a></li>
-            </ul>
+            <?php
+            $stmt = $db->prepare('select id, name, message, start_at, end_at from events  order by start_at asc');
+            $stmt->execute();
+
+            $events = $stmt->fetchAll();
+            foreach ($events as $event) : ?>
+                <?php
+                $start_date = strtotime($event['start_at']);
+                $end_date = strtotime($event['end_at']);
+                ?>
+                <div class="modal-open bg-white mb-3 p-4 flex justify-between rounded-md shadow-md cursor-pointer" id="event-<?php echo $event['id']; ?>">
+                    <div>
+                        <h3 class="font-bold text-lg mb-2"><?php echo $event['name'] ?></h3>
+                        <p><?php echo h($event['start_at']); ?> ~ <?php echo h($event['end_at']); ?></p>
+                        <?php if ($event['message']) : ?>
+                            <div><?php echo ($event['message']); ?></div>
+                        <?php endif; ?>
+                        <p class="text-xs text-gray-600">
+                            [<a href="event-edit.php?id=<?php echo h($event['id']); ?>" style="color: #F33;">編集</a>]
+                        </p>
+                    </div>
+                </div>
+            <?php endforeach; ?>
         </div>
     </main>
 </body>


### PR DESCRIPTION
## 関連イシュー

- #44 

## 検証したこと

- [x] 管理画面から登録済みのイベント一覧が確認できること、
- [x] また、イベントを選択してイベント名、開催日時、イベント内容を変更できること
- [x] 管理画面には管理者のみログイン出来る

## エビデンス
<img width="1680" alt="スクリーンショット 2022-09-07 18 50 23" src="https://user-images.githubusercontent.com/94722910/188851253-79c5dc6e-98ca-4056-b1cf-cdf76cda6b97.png">
<img width="1680" alt="スクリーンショット 2022-09-07 18 55 27" src="https://user-images.githubusercontent.com/94722910/188851303-563b9c7a-4117-47ec-8d47-0299b73c35fc.png">
<img width="1680" alt="スクリーンショット 2022-09-07 18 55 31" src="https://user-images.githubusercontent.com/94722910/188851338-d7ae45d4-bab4-48de-944a-8b02814acc11.png">

