### PR TITLE
#40 通知機能 Issue3 イベントの前日にメールで通知する 通知する先は参加としている人のみ 

### DIFF
--- a/src/mailtest.php
+++ b/src/mailtest.php
@@ -1,24 +1,91 @@
 <?php
+require('dbconnect.php');
+
+// 明日あるイベントを取ってくる
+// $stmt = $db->prepare('SELECT name ,start_at from events where start_at < now() + interval 24 hour and start_at > now()');
+// $stmt->execute();
+// $tomorrow_events = $stmt->fetchAll();
+
+// {
+//     [0] => {
+//         'neme' = '信田';
+//         'email' = 'email1@email'
+//         'event_tomorrow' = [
+//             'neme' = '縦もく'
+//             'neme' = 'テックもくもく'
+//             'neme' = 'テックもくもく'
+//             'neme' = 'テックもくもく'
+//         ]
+//     }
+//     [1] => {
+//         'neme' = '信田';
+//         'email' = 'email1@email'
+//         'event_tomorrow' = [
+//             'neme' = '縦もく'
+//             'neme' = 'テックもくもく'
+//             'neme' = 'テックもくもく'
+//             'neme' = 'テックもくもく'
+//         ]
+//     }
+// }
+
+
+// ユーザー全部取ってくる
+$stmt = $db->prepare(
+    'SELECT events.name AS events_name,users.id AS user_id, users.name AS users_name, users.email, events.start_at 
+    FROM event_attendance LEFT OUTER JOIN events ON event_attendance.event_id = events.id 
+    RIGHT OUTER JOIN users ON event_attendance.user_id = users.id 
+    WHERE start_at < now() + interval 24 hour and start_at > now()'
+);
+$stmt->execute();
+$users = $stmt->fetchAll();
+
+// 配列の生成
+// 空の配列準備　エラーの予防
+$set = [];
+
+foreach ($users as $user) :
+    // 実際の値は$set[0];$set[1];
+    $set[$user['user_id']]['user_name'] = $user['users_name'];
+    $set[$user['user_id']]['email'] = $user['email'];
+    $set[$user['user_id']]['event_tomorrow'][] = $user['events_name'];
+endforeach;
+
+// ここからメール
 
 mb_language('ja');
 mb_internal_encoding('UTF-8');
 
-$to = "hackathon-teamX@posse-ap.com";
-$subject = "PHPからメール送信サンプル";
-$body = "本文";
-$headers = ["From"=>"system@posse-ap.com", "Content-Type"=>"text/plain; charset=UTF-8", "Content-Transfer-Encoding"=>"8bit"];
 
-$name = "テスト";
-$date = "2021年08月01日（日） 21:00~23:00";
-$event = "縦モク";
-$body = <<<EOT
-{$name}さん
+// 人物ごとに送るためにforeach
+foreach ($set as $s) :
 
-${date}に${event}を開催します。
-参加／不参加の回答をお願いします。
+    // foreach ([$user['user_id']]['event_tomorrow'] as $event) :
+    //         $s_message .= "・".$user['events_name']."\n  ";
 
-http://localhost/
-EOT;
+    //         var_dump($event);
+    // endforeach;
 
-mb_send_mail($to, $subject, $body, $headers);
+
+    $to_array = [$s['email']];
+    $to = implode(',', $to_array);
+    $headers = ["From" => "system@posse-ap.com", "Content-Type" => "text/plain; charset=UTF-8", "Content-Transfer-Encoding" => "8bit"];
+    $subject = "明日のイベントのリマインド";
+    $name_array = [$s['user_name']];
+    $name = implode($name_array);
+    $date = date('Y-m-d', strtotime('+1 day'));
+
+    $invite_events = '';
+    foreach ($s['event_tomorrow'] as $invite_event) :
+        $invite_events .= "・" . $invite_event . "\n  ";
+    endforeach;
+
+    $body = <<<EOT
+    {$name}さん${date}に
+    {$invite_events}
+    を開催します。把握よろしくお願いします。
+    EOT;
+
+    mb_send_mail($to, $subject, $body, $headers);
+endforeach;
 echo "メールを送信しました";

--- a/src/mailtest.php
+++ b/src/mailtest.php
@@ -35,7 +35,7 @@ $stmt = $db->prepare(
     'SELECT events.name AS event_name,users.id AS user_id, users.name AS users_name, users.email,events.message, events.start_at 
     FROM event_attendance LEFT OUTER JOIN events ON event_attendance.event_id = events.id 
     RIGHT OUTER JOIN users ON event_attendance.user_id = users.id 
-    WHERE start_at < now() + interval 24 hour and start_at > now()'
+    WHERE start_at < now() + interval 24 hour and start_at > now() and status_id = 1'
 );
 $stmt->execute();
 $users = $stmt->fetchAll();

--- a/src/mailtest.php
+++ b/src/mailtest.php
@@ -11,7 +11,7 @@ require('dbconnect.php');
 //         'neme' = '信田';
 //         'email' = 'email1@email'
 //         'event_tomorrow' = [
-//             'neme' = '縦もく'
+//             '縦もく' = '詳細です'
 //             'neme' = 'テックもくもく'
 //             'neme' = 'テックもくもく'
 //             'neme' = 'テックもくもく'
@@ -32,7 +32,7 @@ require('dbconnect.php');
 
 // ユーザー全部取ってくる
 $stmt = $db->prepare(
-    'SELECT events.name AS events_name,users.id AS user_id, users.name AS users_name, users.email, events.start_at 
+    'SELECT events.name AS event_name,users.id AS user_id, users.name AS users_name, users.email,events.message, events.start_at 
     FROM event_attendance LEFT OUTER JOIN events ON event_attendance.event_id = events.id 
     RIGHT OUTER JOIN users ON event_attendance.user_id = users.id 
     WHERE start_at < now() + interval 24 hour and start_at > now()'
@@ -41,15 +41,20 @@ $stmt->execute();
 $users = $stmt->fetchAll();
 
 // 配列の生成
-// 空の配列準備　エラーの予防
+// 空の配列準備 エラーの予防
 $set = [];
 
 foreach ($users as $user) :
     // 実際の値は$set[0];$set[1];
     $set[$user['user_id']]['user_name'] = $user['users_name'];
     $set[$user['user_id']]['email'] = $user['email'];
-    $set[$user['user_id']]['event_tomorrow'][] = $user['events_name'];
+    $set[$user['user_id']]['event_tomorrow']['event_id']['event_name'] = $user['event_name'];
+    $set[$user['user_id']]['event_tomorrow']['event_id']['event_detail'] = $user['message'];
 endforeach;
+
+echo '<pre>'; 
+    var_dump($set);
+echo '</pre>';
 
 // ここからメール
 
@@ -77,7 +82,7 @@ foreach ($set as $s) :
 
     $invite_events = '';
     foreach ($s['event_tomorrow'] as $invite_event) :
-        $invite_events .= "・" . $invite_event . "\n  ";
+        $invite_events .= "・" . $invite_event['event_name'] . " 詳細：".  $invite_event['event_detail'] ."\n  ";
     endforeach;
 
     $body = <<<EOT


### PR DESCRIPTION
## 関連イシュー

- #40 

## 検証したこと
バッチを実行すると処理日がイベントの前日の場合メールを送付する
メールの宛先は参加としている人のみ
メールにはイベント名、内容、開催日時を記載する

## エビデンス
![スクリーンショット 2022-09-08 2 05 56](https://user-images.githubusercontent.com/86901919/188938323-e59931fe-32b5-4bf9-b239-da5ecdb8a14b.jpg)
