### PR TITLE
#39 通知機能 Issue2 イベントの前日にメールで通知する 通知する先はユーザレコードの人すべて

### DIFF
--- a/src/mailtest.php
+++ b/src/mailtest.php
@@ -30,30 +30,41 @@ require('dbconnect.php');
 // }
 
 
-// ユーザー全部取ってくる
+// 一日後までにあるイベントを取得
 $stmt = $db->prepare(
-    'SELECT events.name AS event_name,users.id AS user_id, users.name AS users_name, users.email,events.message, events.start_at 
-    FROM event_attendance LEFT OUTER JOIN events ON event_attendance.event_id = events.id 
-    RIGHT OUTER JOIN users ON event_attendance.user_id = users.id 
-    WHERE start_at < now() + interval 24 hour and start_at > now()'
+    'SELECT name,message,start_at FROM events 
+    WHERE start_at < now() + interval 24 hour and start_at > now();'
 );
 $stmt->execute();
-$users = $stmt->fetchAll();
+$events = $stmt->fetchAll();
+
+echo '<pre>'; 
+    var_dump($events);
+echo '</pre>';
+
+// 全ユーザーを取得
+$userstmt = $db->prepare(
+    'SELECT name,email FROM users;'
+);
+$userstmt->execute();
+$userlists = $userstmt->fetchAll();
+
+
 
 // 配列の生成
 // 空の配列準備 エラーの予防
-$set = [];
+// $set = [];
 
-foreach ($users as $user) :
-    // 実際の値は$set[0];$set[1];
-    $set[$user['user_id']]['user_name'] = $user['users_name'];
-    $set[$user['user_id']]['email'] = $user['email'];
-    $set[$user['user_id']]['event_tomorrow']['event_id']['event_name'] = $user['event_name'];
-    $set[$user['user_id']]['event_tomorrow']['event_id']['event_detail'] = $user['message'];
-endforeach;
+// foreach ($users as $user) :
+//     // 実際の値は$set[0];$set[1];
+//     $set[$user['user_id']]['user_name'] = $user['users_name'];
+//     $set[$user['user_id']]['email'] = $user['email'];
+//     $set[$user['user_id']]['event_tomorrow']['event_id']['event_name'] = $user['event_name'];
+//     $set[$user['user_id']]['event_tomorrow']['event_id']['event_detail'] = $user['message'];
+// endforeach;
 
 echo '<pre>'; 
-    var_dump($set);
+    var_dump($userlists);
 echo '</pre>';
 
 // ここからメール
@@ -61,9 +72,13 @@ echo '</pre>';
 mb_language('ja');
 mb_internal_encoding('UTF-8');
 
+$invite_events = '';
+foreach ($events as $invite_event) :
+    $invite_events .= "・" . $invite_event['name'] . " 詳細：".  $invite_event['message'] ."\n  ";
+endforeach;
 
 // 人物ごとに送るためにforeach
-foreach ($set as $s) :
+foreach ($userlists as $user) :
 
     // foreach ([$user['user_id']]['event_tomorrow'] as $event) :
     //         $s_message .= "・".$user['events_name']."\n  ";
@@ -72,18 +87,16 @@ foreach ($set as $s) :
     // endforeach;
 
 
-    $to_array = [$s['email']];
+    $to_array = [$user['email']];
     $to = implode(',', $to_array);
+    // $to = $to_array . '';
     $headers = ["From" => "system@posse-ap.com", "Content-Type" => "text/plain; charset=UTF-8", "Content-Transfer-Encoding" => "8bit"];
     $subject = "明日のイベントのリマインド";
-    $name_array = [$s['user_name']];
+    $name_array = [$user['name']];
     $name = implode($name_array);
     $date = date('Y-m-d', strtotime('+1 day'));
 
-    $invite_events = '';
-    foreach ($s['event_tomorrow'] as $invite_event) :
-        $invite_events .= "・" . $invite_event['event_name'] . " 詳細：".  $invite_event['event_detail'] ."\n  ";
-    endforeach;
+
 
     $body = <<<EOT
     {$name}さん${date}に


### PR DESCRIPTION
## 関連イシュー

- #39 

## 検証したこと

バッチを実行すると処理日がイベントの前日の場合メールを送付する
メールの宛先はユーザレコードの人全て
メールにはイベント名、内容、開催日時を記載する

## エビデンス

![スクリーンショット 2022-09-08 11 14 44](https://user-images.githubusercontent.com/86901919/189018515-21728963-bbe6-4718-80a5-b911d2af7210.jpg)
![スクリーンショット 2022-09-08 11 14 50](https://user-images.githubusercontent.com/86901919/189018559-fdda026f-1888-40ba-8e3e-a8548239c8a8.jpg)

