### PR TITLE
#46 未回答管理 Issue2 イベントの3日前にメールで通知する 通知する先はユーザレコードの人すべて 

### DIFF
--- a/src/mailtest.php
+++ b/src/mailtest.php
@@ -94,7 +94,7 @@ foreach ($userlists as $user) :
     $subject = "三日後のイベントについて回答をお願いします！";
     $name_array = [$user['name']];
     $name = implode($name_array);
-    $date = date('Y-m-d', strtotime('+1 day'));
+    $date = date('Y-m-d', strtotime('+3 day'));
     $url = "http://localhost";
 
 

--- a/src/mailtest.php
+++ b/src/mailtest.php
@@ -30,17 +30,17 @@ require('dbconnect.php');
 // }
 
 
-// 一日後までにあるイベントを取得
+// 三日後にあるイベントを取得
 $stmt = $db->prepare(
     'SELECT name,message,start_at FROM events 
-    WHERE start_at < now() + interval 24 hour and start_at > now();'
+    WHERE  start_at < now() + interval 72 hour and start_at > now() + interval 48 hour;'
 );
 $stmt->execute();
 $events = $stmt->fetchAll();
 
-echo '<pre>'; 
-    var_dump($events);
-echo '</pre>';
+// echo '<pre>'; 
+//     var_dump($events);
+// echo '</pre>';
 
 // 全ユーザーを取得
 $userstmt = $db->prepare(
@@ -63,9 +63,9 @@ $userlists = $userstmt->fetchAll();
 //     $set[$user['user_id']]['event_tomorrow']['event_id']['event_detail'] = $user['message'];
 // endforeach;
 
-echo '<pre>'; 
-    var_dump($userlists);
-echo '</pre>';
+// echo '<pre>'; 
+//     var_dump($userlists);
+// echo '</pre>';
 
 // ここからメール
 
@@ -91,17 +91,18 @@ foreach ($userlists as $user) :
     $to = implode(',', $to_array);
     // $to = $to_array . '';
     $headers = ["From" => "system@posse-ap.com", "Content-Type" => "text/plain; charset=UTF-8", "Content-Transfer-Encoding" => "8bit"];
-    $subject = "明日のイベントのリマインド";
+    $subject = "三日後のイベントについて回答をお願いします！";
     $name_array = [$user['name']];
     $name = implode($name_array);
     $date = date('Y-m-d', strtotime('+1 day'));
-
+    $url = "http://localhost";
 
 
     $body = <<<EOT
     {$name}さん${date}に
     {$invite_events}
-    を開催します。把握よろしくお願いします。
+    を開催します。こちらのURLより参加不参加の回答をよろしくお願いします。
+    {$url}
     EOT;
 
     mb_send_mail($to, $subject, $body, $headers);

--- a/src/mailtest.php
+++ b/src/mailtest.php
@@ -30,30 +30,41 @@ require('dbconnect.php');
 // }
 
 
-// ユーザー全部取ってくる
+// 一日後までにあるイベントを取得
 $stmt = $db->prepare(
-    'SELECT events.name AS event_name,users.id AS user_id, users.name AS users_name, users.email,events.message, events.start_at 
-    FROM event_attendance LEFT OUTER JOIN events ON event_attendance.event_id = events.id 
-    RIGHT OUTER JOIN users ON event_attendance.user_id = users.id 
-    WHERE start_at < now() + interval 24 hour and start_at > now()'
+    'SELECT name,message,start_at FROM events 
+    WHERE start_at < now() + interval 24 hour and start_at > now();'
 );
 $stmt->execute();
-$users = $stmt->fetchAll();
+$events = $stmt->fetchAll();
+
+echo '<pre>'; 
+    var_dump($events);
+echo '</pre>';
+
+// 全ユーザーを取得
+$userstmt = $db->prepare(
+    'SELECT name,email FROM users;'
+);
+$userstmt->execute();
+$userlists = $userstmt->fetchAll();
+
+
 
 // 配列の生成
 // 空の配列準備 エラーの予防
-$set = [];
+// $set = [];
 
-foreach ($users as $user) :
-    // 実際の値は$set[0];$set[1];
-    $set[$user['user_id']]['user_name'] = $user['users_name'];
-    $set[$user['user_id']]['email'] = $user['email'];
-    $set[$user['user_id']]['event_tomorrow']['event_id']['event_name'] = $user['event_name'];
-    $set[$user['user_id']]['event_tomorrow']['event_id']['event_detail'] = $user['message'];
-endforeach;
+// foreach ($users as $user) :
+//     // 実際の値は$set[0];$set[1];
+//     $set[$user['user_id']]['user_name'] = $user['users_name'];
+//     $set[$user['user_id']]['email'] = $user['email'];
+//     $set[$user['user_id']]['event_tomorrow']['event_id']['event_name'] = $user['event_name'];
+//     $set[$user['user_id']]['event_tomorrow']['event_id']['event_detail'] = $user['message'];
+// endforeach;
 
 echo '<pre>'; 
-    var_dump($set);
+    var_dump($userlists);
 echo '</pre>';
 
 // ここからメール
@@ -61,9 +72,13 @@ echo '</pre>';
 mb_language('ja');
 mb_internal_encoding('UTF-8');
 
+$invite_events = '';
+foreach ($events as $invite_event) :
+    $invite_events .= "・" . $invite_event['name'] . " 詳細：".  $invite_event['message'] ."\n  ";
+endforeach;
 
 // 人物ごとに送るためにforeach
-foreach ($set as $s) :
+foreach ($userlists as $user) :
 
     // foreach ([$user['user_id']]['event_tomorrow'] as $event) :
     //         $s_message .= "・".$user['events_name']."\n  ";
@@ -72,18 +87,16 @@ foreach ($set as $s) :
     // endforeach;
 
 
-    $to_array = [$s['email']];
+    $to_array = [$user['email']];
     $to = implode(',', $to_array);
+    // $to = $to_array . '';
     $headers = ["From" => "system@posse-ap.com", "Content-Type" => "text/plain; charset=UTF-8", "Content-Transfer-Encoding" => "8bit"];
     $subject = "明日のイベントのリマインド";
-    $name_array = [$s['user_name']];
+    $name_array = [$user['name']];
     $name = implode($name_array);
     $date = date('Y-m-d', strtotime('+1 day'));
 
-    $invite_events = '';
-    foreach ($s['event_tomorrow'] as $invite_event) :
-        $invite_events .= "・" . $invite_event['event_name'] . " 詳細：".  $invite_event['event_detail'] ."\n  ";
-    endforeach;
+
 
     $body = <<<EOT
     {$name}さん${date}に


### PR DESCRIPTION
## 関連イシュー

- #46 

## 検証したこと

バッチを実行すると処理日がイベントの3日前の場合メールを送付する
メールの宛先はユーザレコードの人全て
メールにはイベント名、内容、開催日時、回答を促す内容を記載する

## エビデンス
![スクリーンショット 2022-09-08 11 34 29](https://user-images.githubusercontent.com/86901919/189021080-e6576062-ab25-421b-a5d2-a67882d1a4b2.jpg)
![スクリーンショット 2022-09-08 11 34 39](https://user-images.githubusercontent.com/86901919/189021092-8cabf0d0-098a-4f64-b4c5-2d6c35f590fb.jpg)


