### PR TITLE
#41 通知機能 Issue4 イベントの前日にメールで通知する 通知する先は参加としている人のみ slack通知

### DIFF
--- a/src/slack.php
+++ b/src/slack.php
@@ -1,26 +1,5 @@
 <?php
 
-// mb_language('ja');
-// mb_internal_encoding('UTF-8');
-
-// $to = "hackathon-teamX@posse-ap.com";
-// $subject = "PHPからメール送信サンプル";
-// $body = "本文";
-// $headers = ["From"=>"system@posse-ap.com", "Content-Type"=>"text/plain; charset=UTF-8", "Content-Transfer-Encoding"=>"8bit"];
-
-// $name = "テスト";
-// $date = "2021年08月01日（日） 21:00~23:00";
-// $event = "縦モク";
-// $body = <<<EOT
-// {$name}さん
-// ${date}に${event}を開催します。
-// 参加／不参加の回答をお願いします。
-// http://localhost/
-// EOT;
-
-// mb_send_mail($to, $subject, $body, $headers);
-// echo "メールを送信しました";
-
 $headers = [
     'Authorization: Bearer xoxb-1030735452658-2430137901444-RuYFtS6N6zl4uZQSah0CLJ0b', //（1)
     'Content-Type: application/json;charset=utf-8'
@@ -30,7 +9,7 @@ $url = "https://slack.com/api/chat.postMessage"; //(2)
 
 //(3)
 $post_fields = [
-    "channel" => "posse2-hackathon-202209-team2c",
+    "channel" => "#posse2-hackathon-202209-team2c",
     "text" => "初めてのSlack Web APIからのメッセージ",
     "as_user" => true
 ];
@@ -52,3 +31,27 @@ $result = curl_exec($ch);
 curl_close($ch);
 
 echo "メールを送信しました";
+
+// $url = "https://hooks.slack.com/services/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";
+// $message = [
+//   "channel" => "#posse2-hackathon-202209-team2c",
+//   "text" => "メッセージ内容"
+// ];
+
+// $ch = curl_init();
+
+// $options = [
+//   CURLOPT_URL => $url,
+//   // 返り値を文字列で返す
+//   CURLOPT_RETURNTRANSFER => true,
+//   CURLOPT_SSL_VERIFYPEER => false,
+//   // POST
+//   CURLOPT_POST => true,
+//   CURLOPT_POSTFIELDS => http_build_query([
+//     'payload' => json_encode($message)
+//   ])
+// ];
+
+// curl_setopt_array($ch, $options);
+// curl_exec($ch);
+// curl_close($ch);

--- a/src/slack.php
+++ b/src/slack.php
@@ -1,0 +1,54 @@
+<?php
+
+// mb_language('ja');
+// mb_internal_encoding('UTF-8');
+
+// $to = "hackathon-teamX@posse-ap.com";
+// $subject = "PHPからメール送信サンプル";
+// $body = "本文";
+// $headers = ["From"=>"system@posse-ap.com", "Content-Type"=>"text/plain; charset=UTF-8", "Content-Transfer-Encoding"=>"8bit"];
+
+// $name = "テスト";
+// $date = "2021年08月01日（日） 21:00~23:00";
+// $event = "縦モク";
+// $body = <<<EOT
+// {$name}さん
+// ${date}に${event}を開催します。
+// 参加／不参加の回答をお願いします。
+// http://localhost/
+// EOT;
+
+// mb_send_mail($to, $subject, $body, $headers);
+// echo "メールを送信しました";
+
+$headers = [
+    'Authorization: Bearer xoxb-1030735452658-2430137901444-RuYFtS6N6zl4uZQSah0CLJ0b', //（1)
+    'Content-Type: application/json;charset=utf-8'
+];
+
+$url = "https://slack.com/api/chat.postMessage"; //(2)
+
+//(3)
+$post_fields = [
+    "channel" => "posse2-hackathon-202209-team2c",
+    "text" => "初めてのSlack Web APIからのメッセージ",
+    "as_user" => true
+];
+
+$options = [
+    CURLOPT_URL => $url,
+    CURLOPT_RETURNTRANSFER => true,
+    CURLOPT_HTTPHEADER => $headers,
+    CURLOPT_POST => true,
+    CURLOPT_POSTFIELDS => json_encode($post_fields)
+];
+
+$ch = curl_init();
+
+curl_setopt_array($ch, $options);
+
+$result = curl_exec($ch);
+
+curl_close($ch);
+
+echo "メールを送信しました";

--- a/src/slack.php
+++ b/src/slack.php
@@ -1,40 +1,65 @@
 <?php
+require('dbconnect.php');
 
-$headers = [
-    'Authorization: Bearer xoxb-1030735452658-2430137901444-RuYFtS6N6zl4uZQSah0CLJ0b', //（1)
-    'Content-Type: application/json;charset=utf-8'
-];
+// ユーザー全部取ってくる
+$stmt = $db->prepare(
+    'SELECT events.id AS event_id, events.name AS event_name,users.id AS user_id, users.name AS user_name, users.email,events.message, events.start_at 
+    FROM event_attendance LEFT OUTER JOIN events ON event_attendance.event_id = events.id 
+    RIGHT OUTER JOIN users ON event_attendance.user_id = users.id 
+    WHERE start_at < now() + interval 24 hour and start_at > now() and status_id = 1'
+);
+$stmt->execute();
+$users = $stmt->fetchAll();
 
-$url = "https://slack.com/api/chat.postMessage"; //(2)
+foreach ($users as $user) :
+    // 実際の値は$set[0];$set[1];
+    $set[$user['event_id']]['event_name'] = $user['event_name'];
+    $set[$user['event_id']]['message'] = $user['message'];
+    $set[$user['event_id']]['start_at'] = $user['start_at'];
+    $set[$user['event_id']]['participants'][] = $user['user_name'];
+endforeach;
 
-//(3)
-$post_fields = [
-    "channel" => "#posse2-hackathon-202209-team2c",
-    "text" => "初めてのSlack Web APIからのメッセージ",
-    "as_user" => true
-];
+// echo '<pre>';
+// var_dump($set);
+// echo '</pre>';
 
-$options = [
-    CURLOPT_URL => $url,
-    CURLOPT_RETURNTRANSFER => true,
-    CURLOPT_HTTPHEADER => $headers,
-    CURLOPT_POST => true,
-    CURLOPT_POSTFIELDS => json_encode($post_fields)
-];
+foreach ($set as $s) :
+    $invite_events = '';
+    foreach ($s['participants'] as $p) :
+        $invite_events .= "・@" . $p . " \n  ";
+    endforeach;
+    $text = "明日のイベントのリマインド \n イベント名:" . $s['event_name'] . "\n 開催日時:" . $s['start_at'] . "\n 詳細:" . $s['message'] .  "\n 参加者: \n" . $invite_events;
 
-$ch = curl_init();
+    $url = "https://hooks.slack.com/services/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";
+    $message = [
+        "channel" => "#slackbot-posse2-hackathon-202209-team2c",
+        "text" => $text
+    ];
 
-curl_setopt_array($ch, $options);
+    $ch = curl_init();
 
-$result = curl_exec($ch);
+    $options = [
+        CURLOPT_URL => $url,
+        // 返り値を文字列で返す
+        CURLOPT_RETURNTRANSFER => true,
+        CURLOPT_SSL_VERIFYPEER => false,
+        // POST
+        CURLOPT_POST => true,
+        CURLOPT_POSTFIELDS => http_build_query([
+            'payload' => json_encode($message)
+        ])
+    ];
 
-curl_close($ch);
-
+    curl_setopt_array($ch, $options);
+    curl_exec($ch);
+    curl_close($ch);
+endforeach;
 echo "メールを送信しました";
 
-// $url = "https://hooks.slack.com/services/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";
+
+// $url = "https://hooks.slack.com/services/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";
 // $message = [
-//   "channel" => "#posse2-hackathon-202209-team2c",
+//   "channel" => "#slackbot-posse2-hackathon-202209-team2c",
 //   "text" => "メッセージ内容"
 // ];
 


### PR DESCRIPTION
## 関連イシュー

- #41 

## 検証したこと
- [x] バッチを実行すると処理日がイベントの前日の場合Slackで通知する
- [x] メッセージの宛先は参加としている人のみ、チャンネルはチームごとに用意するチャンネル→自分で用意しました。
- [x] メッセージにはイベント名、内容、開催日時を記載する

## エビデンス
<img width="1680" alt="スクリーンショット 2022-09-08 16 38 56" src="https://user-images.githubusercontent.com/94722910/189065294-32899be5-7491-46f8-8cb6-8c7fffddf408.png">
