### PR TITLE
#37 イベント参加管理 Issue5 イベント詳細画面のイベント参加人数をクリックすると、 参加者が一覧表示される

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,6 @@ services:
       - PMA_USER=posse_user
       - PMA_PASSWORD=password
     ports:
-      - "4040:80"
+      - "4041:80"
     volumes:
       - ./docker/phpmyadmin/sessions:/sessions

--- a/src/api/getModalInfo.php
+++ b/src/api/getModalInfo.php
@@ -24,6 +24,15 @@ if (isset($_GET['eventId'])) {
     $stmt->execute(array($eventId));
     $total_participants = $stmt->fetch();
 
+    //参加ユーザー名取得
+    $stmt = $db->prepare('SELECT event_attendance.user_id, users.name
+    FROM events 
+    LEFT JOIN event_attendance ON events.id = event_attendance.event_id 
+    Right JOIN users ON event_attendance.user_id=users.id
+    WHERE events.id =? AND status_id=1 ');
+    $stmt->execute(array($eventId));
+    $participants_name = $stmt->fetchAll();
+
 
     $start_date = strtotime($event['start_at']);
     $end_date = strtotime($event['end_at']);
@@ -43,6 +52,7 @@ if (isset($_GET['eventId'])) {
       'message' => $event['message'],
       'status' => $status,
       'status_id' => $status_id['status_id'],
+      'participants_name' => $participants_name,
       'deadline' => date("m月d日", strtotime('-3 day', $end_date)),
     ];
 

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -1,0 +1,7 @@
+nav {
+  display: none;
+}
+
+.nav-open {
+  padding: 15px;
+}

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -26,7 +26,8 @@ async function openModal(eventId) {
     const url = '/api/getModalInfo.php?eventId=' + eventId
     const res = await fetch(url)
     const event = await res.json()
-    console.dir(event.total_participants['total_participants'] || (Number(false)));
+    console.dir(event.participants_name
+    );
     let modalHTML = `
       <h2 class="text-md font-bold mb-3">${event.name}</h2>
       <p class="text-sm">${event.date}（${event.day_of_week}）</p>
@@ -39,17 +40,25 @@ async function openModal(eventId) {
       </p>
 
       <hr class="my-4">
-
-      <p class="text-sm"><span class="text-xl">${event.total_participants['total_participants'] || 0}</span>人参加 ></p>
+      <details >
+        <summary class=" text-sm">
+      <span class=" text-xl">${event.total_participants['total_participants'] || 0}</span>人参加 >
+      </summary>
     `
+    event.participants_name.forEach(participant => {
+      modalHTML +=
+        `<p>
+      ${participant.name}
+      </p>`
+
+    });
+    modalHTML += ` </details>`
     switch (event.status_id) {
       case 0:
         modalHTML += `
           <div class="text-center mt-6">
-            <!--
             <p class="text-lg font-bold text-yellow-400">未回答</p>
             <p class="text-xs text-yellow-400">期限 ${event.deadline}</p>
-            -->
           </div>
           <div class="flex mt-5">
             <button class="flex-1 bg-gray-300 py-2 mx-3 rounded-3xl text-white text-lg font-bold" onclick="participateEvent(${eventId})">参加する</button>
@@ -147,3 +156,6 @@ const clicked = () => {
   document.getElementById('filtter-button-participating').classList.remove('bg-blue-600');
 
 }
+
+
+


### PR DESCRIPTION
## 関連イシュー

- #37 

## 検証したこと
イベント詳細画面のイベント参加人数をクリックすると、アコーディオンで参加者の名前が一覧で表示される
再度クリックすると閉じる

## エビデンス
![スクリーンショット 2022-09-08 21 58 32](https://user-images.githubusercontent.com/86901919/189127988-7bd17488-0239-4e98-ac57-a00d08375aae.jpg)
![スクリーンショット 2022-09-08 21 58 40](https://user-images.githubusercontent.com/86901919/189128017-b0a5a89f-f3a1-437d-b139-4b1f854165d9.jpg)

